### PR TITLE
Fixed tests to include both custom and html callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ it("Child callback causes click count to increase", async () => {
   await act(() =>
     getMockComponentPropCalls(Child)
       ?.at(-1)
-      ?.onClick?.({} as any)
+      ?.onComplicatedCallback?.({} as any)
   );
 
   // Assert

--- a/src/tests-class-component/child-with-children/test-asset.child.tsx
+++ b/src/tests-class-component/child-with-children/test-asset.child.tsx
@@ -1,11 +1,10 @@
 import React, { HtmlHTMLAttributes } from "react";
 
-export type ChildProps = React.PropsWithChildren<
-  Pick<HtmlHTMLAttributes<HTMLButtonElement>, "onClick"> & {
-    someData: string;
-    onPointerEnter: () => void;
-  }
->;
+export type ChildProps = React.PropsWithChildren<{
+  onClick: HtmlHTMLAttributes<HTMLButtonElement>["onClick"];
+  someData: string;
+  onComplicatedCallback: () => void;
+}>;
 
 export class Child extends React.Component<ChildProps> {
   render() {

--- a/src/tests-class-component/child-with-children/test-asset.parent.tsx
+++ b/src/tests-class-component/child-with-children/test-asset.parent.tsx
@@ -40,7 +40,7 @@ export class Parent extends React.Component<ParentProps, ParentState> {
           data-testid={parentTestIdMap.child}
           onClick={this.handleChildClick}
           someData="someData"
-          onPointerEnter={() => {}}
+          onComplicatedCallback={() => {}}
         >
           Increment
         </Child>

--- a/src/tests-class-component/child-with-props/index.test.tsx
+++ b/src/tests-class-component/child-with-props/index.test.tsx
@@ -40,7 +40,7 @@ describe("Github issue #7 - Using ReturnType on createMockComponent", () => {
   it("Renders dynamic import child", async () => {
     // Arrange
     const spy = jest.fn();
-    const result = render(<Child onClick={spy} someData="someData" onPointerEnter={() => {}} />);
+    const result = render(<Child onClick={spy} someData="someData" onComplicatedCallback={() => {}} />);
 
     // Act
     await userEvent.click(result.getByRole("button"));

--- a/src/tests-class-component/child-with-props/test-asset.child.tsx
+++ b/src/tests-class-component/child-with-props/test-asset.child.tsx
@@ -1,8 +1,9 @@
 import React, { HtmlHTMLAttributes } from "react";
 
-export type ChildProps = Pick<HtmlHTMLAttributes<HTMLButtonElement>, "onClick"> & {
+export type ChildProps = {
+  onClick: HtmlHTMLAttributes<HTMLButtonElement>["onClick"];
   someData: string;
-  onPointerEnter: () => void;
+  onComplicatedCallback: () => void;
 };
 
 export class Child extends React.Component<ChildProps> {

--- a/src/tests-class-component/child-with-props/test-asset.parent.tsx
+++ b/src/tests-class-component/child-with-props/test-asset.parent.tsx
@@ -40,7 +40,7 @@ export class Parent extends React.Component<ParentProps, ParentState> {
           data-testid={parentTestIdMap.child}
           onClick={this.handleChildClick}
           someData="someData"
-          onPointerEnter={() => {}}
+          onComplicatedCallback={() => {}}
         />
       </div>
     );

--- a/src/tests-functional-component/child-with-children/test-asset.child.tsx
+++ b/src/tests-functional-component/child-with-children/test-asset.child.tsx
@@ -1,11 +1,10 @@
 import React, { HtmlHTMLAttributes } from "react";
 
-export type ChildProps = React.PropsWithChildren<
-  Pick<HtmlHTMLAttributes<HTMLButtonElement>, "onClick"> & {
-    someData: string;
-    onPointerEnter: () => void;
-  }
->;
+export type ChildProps = React.PropsWithChildren<{
+  onClick: HtmlHTMLAttributes<HTMLButtonElement>["onClick"];
+  someData: string;
+  onComplicatedCallback: () => void;
+}>;
 
 export function Child(props: ChildProps) {
   const { onClick, children } = props;

--- a/src/tests-functional-component/child-with-children/test-asset.parent.tsx
+++ b/src/tests-functional-component/child-with-children/test-asset.parent.tsx
@@ -25,7 +25,7 @@ export function Parent(props: ParentProps) {
         data-testid={parentTestIdMap.child}
         onClick={handleChildClick}
         someData="someData"
-        onPointerEnter={() => {}}
+        onComplicatedCallback={() => {}}
       >
         Increment
       </Child>

--- a/src/tests-functional-component/child-with-props/index.test.tsx
+++ b/src/tests-functional-component/child-with-props/index.test.tsx
@@ -40,7 +40,7 @@ describe("Github issue #7 - Using ReturnType on createMockComponent", () => {
   it("Renders dynamic import child", async () => {
     // Arrange
     const spy = jest.fn();
-    const result = render(<Child onClick={spy} someData="someData" onPointerEnter={() => {}} />);
+    const result = render(<Child onClick={spy} someData="someData" onComplicatedCallback={() => {}} />);
 
     // Act
     await userEvent.click(result.getByRole("button"));

--- a/src/tests-functional-component/child-with-props/test-asset.child.tsx
+++ b/src/tests-functional-component/child-with-props/test-asset.child.tsx
@@ -1,8 +1,9 @@
 import React, { HtmlHTMLAttributes } from "react";
 
-export type ChildProps = Pick<HtmlHTMLAttributes<HTMLButtonElement>, "onClick"> & {
+export type ChildProps = {
+  onClick: HtmlHTMLAttributes<HTMLButtonElement>["onClick"];
   someData: string;
-  onPointerEnter: () => void;
+  onComplicatedCallback: () => void;
 };
 
 export function Child(props: ChildProps) {

--- a/src/tests-functional-component/child-with-props/test-asset.parent.tsx
+++ b/src/tests-functional-component/child-with-props/test-asset.parent.tsx
@@ -25,7 +25,7 @@ export function Parent(props: ParentProps) {
         data-testid={parentTestIdMap.child}
         onClick={handleChildClick}
         someData="someData"
-        onPointerEnter={() => {}}
+        onComplicatedCallback={() => {}}
       />
     </div>
   );


### PR DESCRIPTION
Our tests had both onClick and onPointerEnter which are both standard HTML callbacks. Instead I changed it to onClick and onComplicatedCallback to get some variety.