### PR TITLE
Add missing imports for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The best option is to check out our [integration tests](./src/tests-functional-c
 ```typescript
 import { render } from "@testing-library/react";
 import React from "react";
-import { it, jest } from "@jest/globals";
+import { it, jest, expect, afterEach } from "@jest/globals";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
 
 // Step 1: if using typescript, import the Prop types for the child component

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 // This file contains some basic tests, for the integration tests see `tests-class-component` and `tests-function-component`
 
-import { describe, it } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
@@ -68,7 +68,7 @@ describe("getMockComponentPropCalls", () => {
       expect(() => {
         getMockComponentPropCalls(
           // @ts-expect-error I'm testing a negative scenario here so I need to break typescript a bit
-          () => React.createElement("span")
+          () => React.createElement("span"),
         );
       }).toThrowError("Did you forget to call createMockComponent");
     });

--- a/src/tests-class-component/child-with-children/index.test.tsx
+++ b/src/tests-class-component/child-with-children/index.test.tsx
@@ -1,9 +1,7 @@
-import { it, jest } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import "@testing-library/jest-dom";
-// https://github.com/testing-library/user-event/issues/1146: userEvent doesn't support Node16 properly
-const userEvent = UserEventModule.default ?? UserEventModule;
 import { act, render } from "@testing-library/react";
-import UserEventModule from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
 
@@ -82,11 +80,10 @@ describe("Arrangeivating the onClick callback directly", () => {
     const result = render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert
@@ -99,11 +96,10 @@ describe("Arrangeivating the onClick callback directly", () => {
     render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert

--- a/src/tests-class-component/child-with-props/index.test.tsx
+++ b/src/tests-class-component/child-with-props/index.test.tsx
@@ -1,9 +1,7 @@
-import { it, jest } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import "@testing-library/jest-dom";
-// https://github.com/testing-library/user-event/issues/1146: userEvent doesn't support Node16 properly
-const userEvent = UserEventModule.default ?? UserEventModule;
 import { act, render } from "@testing-library/react";
-import UserEventModule from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
 
@@ -102,11 +100,10 @@ describe("Activating the onClick callback directly", () => {
     const result = render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert
@@ -119,11 +116,10 @@ describe("Activating the onClick callback directly", () => {
     render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert

--- a/src/tests-class-component/child-without-props/index.test.tsx
+++ b/src/tests-class-component/child-without-props/index.test.tsx
@@ -1,8 +1,8 @@
+import { afterEach, expect, it, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
-import { it, jest } from "@jest/globals";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
-import "@testing-library/jest-dom";
 
 // Step 1:
 // import type allows you to import just the types and not the actual file.

--- a/src/tests-functional-component/child-with-children/index.test.tsx
+++ b/src/tests-functional-component/child-with-children/index.test.tsx
@@ -1,9 +1,7 @@
-import { it, jest } from "@jest/globals";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import "@testing-library/jest-dom";
-// https://github.com/testing-library/user-event/issues/1146: userEvent doesn't support Node16 properly
-const userEvent = UserEventModule.default ?? UserEventModule;
 import { act, render } from "@testing-library/react";
-import UserEventModule from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
 
@@ -82,11 +80,10 @@ describe("Arrangeivating the onClick callback directly", () => {
     const result = render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert
@@ -99,11 +96,10 @@ describe("Arrangeivating the onClick callback directly", () => {
     render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert

--- a/src/tests-functional-component/child-with-props/index.test.tsx
+++ b/src/tests-functional-component/child-with-props/index.test.tsx
@@ -1,9 +1,7 @@
-import { it, jest } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import "@testing-library/jest-dom";
-// https://github.com/testing-library/user-event/issues/1146: userEvent doesn't support Node16 properly
-const userEvent = UserEventModule.default ?? UserEventModule;
 import { act, render } from "@testing-library/react";
-import UserEventModule from "@testing-library/user-event";
+import { userEvent } from "@testing-library/user-event";
 import React from "react";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
 
@@ -102,11 +100,10 @@ describe("Activating the onClick callback directly", () => {
     const result = render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert
@@ -119,11 +116,10 @@ describe("Activating the onClick callback directly", () => {
     render(<Parent />);
 
     // Act
-    await act(
-      () =>
-        getMockComponentPropCalls(Child)
-          ?.at(-1)
-          ?.onClick?.({} as any),
+    await act(() =>
+      getMockComponentPropCalls(Child)
+        ?.at(-1)
+        ?.onClick?.({} as any),
     );
 
     // Assert

--- a/src/tests-functional-component/child-without-props/index.test.tsx
+++ b/src/tests-functional-component/child-without-props/index.test.tsx
@@ -1,8 +1,8 @@
+import { afterEach, expect, it, jest } from "@jest/globals";
+import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 import React from "react";
-import { it, jest } from "@jest/globals";
 import { createMockComponent, getMockComponentPropCalls } from "../../index.js";
-import "@testing-library/jest-dom";
 
 // Step 1:
 // import type allows you to import just the types and not the actual file.


### PR DESCRIPTION
Latest versions of jest (correctly) do not implicitly import expect/describe/etc. Adding those imports in directly.